### PR TITLE
Prepare for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "rust-codecov-cache"
+name = "codecov-cache"
 version = "0.1.0"
 edition = "2021"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,13 @@
 name = "codecov-cache"
 version = "0.1.0"
 edition = "2021"
+authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
+description = "Codecov API caching"
+license = "BSD-3-Clause"
+readme = "README.md"
+repository = "https://github.com/kitsuyui/rust-codecov-cache"
+documentation = "https://docs.rs/codecov-cache"
+categories = ["api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
- Rename crate
- Add information for publishing to crates.io