### PR TITLE
Bump v0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codecov-cache"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "Codecov API caching"
@@ -13,6 +13,6 @@ categories = ["api-bindings"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-codecov = "0.3.3"
+codecov = "0.3.4"
 dirs = "5.0.1"
 serde_json = "1.0.105"


### PR DESCRIPTION
- Update codecov to v0.3.4
