### PR TITLE
Bump version to v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codecov-cache"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Yui Kitsu <kitsuyui+github@kitsuyui.com>"]
 description = "Codecov API caching"


### PR DESCRIPTION
- Breaking changes of rust-codecov https://github.com/kitsuyui/rust-codecov/releases/tag/v0.4.0
